### PR TITLE
Fixed title clipping issue in reaction time task.

### DIFF
--- a/ResearchKit/Common/ORKTitleLabel.m
+++ b/ResearchKit/Common/ORKTitleLabel.m
@@ -38,7 +38,7 @@
 {
     self = [super init];
     if (self) {
-        self.numberOfLines = 2;
+        self.numberOfLines = 0;
         self.textAlignment = NSTextAlignmentLeft;
     }
     return self;


### PR DESCRIPTION
The text "Quickly shake the device when the blue circle appears" is getting clipped as becuase it's been assigned to ORKTitleLabel which is restricted to 2 lines. So modified the number of lines to 0.